### PR TITLE
#67: Brute-force fix for text antialiasing issue.

### DIFF
--- a/src/systems/SDFTextSystem.js
+++ b/src/systems/SDFTextSystem.js
@@ -42,6 +42,7 @@ export class SDFTextSystem extends System {
       const textMesh = new TextMesh();
       textMesh.name = 'textMesh';
       textMesh.anchor = [0, 0];
+      textMesh.renderOrder = 1; //brute-force fix for ugly antialiasing, see issue #67
       this.updateText(textMesh, textComponent);
       e.addComponent(Object3D, {value: textMesh});
     });


### PR DESCRIPTION
Forces all text meshes to render after their background planes so the antialias pixels are blended against the proper color. Hopefully temporary pending a more robust solution in troika-3d-text.