### PR TITLE
Snap turn support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -317,7 +317,7 @@ function setupControllers() {
     controller.addEventListener( 'disconnect', function () {
       this.remove(this.children[0]);
       raycontrol.removeController(this, event.data);
-      snapturn.addController(this, event.data);
+      snapturn.removeController(this, event.data);
     });
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ import { Text, Object3D, AreaChecker } from './components/index.js';
 
 import RayControl from './lib/RayControl.js';
 import Teleport from './lib/Teleport.js';
+import SnapTurn from './lib/SnapTurn.js';
 
 import * as roomHall from './rooms/Hall.js';
 import * as roomPanorama from './rooms/Panorama.js';
@@ -38,7 +39,7 @@ const polyfill = new WebXRPolyfill();
 var clock = new THREE.Clock();
 
 var scene, parent, renderer, camera, controls, context = {};
-var raycontrol, teleport, controllers = [];
+var raycontrol, teleport, snapturn, controllers = [];
 
 var listener, ambientMusic;
 
@@ -268,6 +269,9 @@ export function init() {
     teleport = new Teleport(context);
     context.teleport = teleport;
 
+    snapturn = new SnapTurn(context);
+    context.snapturn = snapturn;
+
     setupControllers();
     roomHall.setup(context);
     roomPanorama.setup(context);
@@ -308,10 +312,12 @@ function setupControllers() {
     controller.addEventListener( 'connected', function ( event ) {
       this.add(model.clone());
       raycontrol.addController(this, event.data);
+      snapturn.addController(this, event.data);
     } );
     controller.addEventListener( 'disconnect', function () {
       this.remove(this.children[0]);
       raycontrol.removeController(this, event.data);
+      snapturn.addController(this, event.data);
     });
   }
 }
@@ -379,6 +385,7 @@ function animate() {
   }
 
   // render current room
+  context.snapturn.execute(context, delta, elapsedTime);
   context.raycontrol.execute(context, delta, elapsedTime);
   rooms[context.room].execute(context, delta, elapsedTime);
   renderer.render(scene, camera);

--- a/src/lib/SnapTurn.js
+++ b/src/lib/SnapTurn.js
@@ -1,0 +1,70 @@
+import {Matrix4, Vector3} from 'three';
+
+const SNAP_TURN_DEGREES = 45;
+
+const doSnapTurn = (() => {
+  const transform = new Matrix4();
+  const invTranslation = new Matrix4();
+  const rotation = new Matrix4();
+  const yAxis = new Vector3(0, 1, 0);
+
+  return (context, direction) => {
+    const headPosition = context.renderer.xr.getCamera(context.camera).position;
+
+    invTranslation.makeTranslation(-headPosition.x, 0, -headPosition.z);
+    rotation.makeRotationAxis(yAxis, direction * SNAP_TURN_DEGREES * Math.PI / 180);
+
+    transform.makeTranslation(headPosition.x, 0, headPosition.z);
+    transform.multiply(rotation);
+    transform.multiply(invTranslation);
+
+    context.cameraRig.applyMatrix(transform);
+  };
+})();
+
+export default class SnapTurn {
+  constructor(context) {
+    this.gamepads = [];
+    this.snapTurning = false;
+  }
+  addController(controller, inputSource) {
+    if (!this.gamepads.includes(inputSource.gamepads)) {
+      this.gamepads.push(inputSource.gamepad);
+    }
+  }
+  removeController(controller, inputSource) {
+    const index = this.gamepads.indexOf(inputSource.gamepads)
+    if (index !== -1) {
+      this.gamepads.splice(index, 1);
+    }
+  }
+  execute(context, delta, elapsedTime) {
+    let anySnapTurning = false;
+    for (let i = 0; i < this.gamepads.length; i++) {
+      const gamepad = this.gamepads[i];
+
+      if (!gamepad.connected || gamepad.mapping !== "xr-standard") continue;
+
+      if (gamepad.axes[2] > 0.75) {
+        if (!this.snapTurning) {
+          doSnapTurn(context, -1);
+          this.snapTurning = true;
+        }
+        anySnapTurning = true;
+        break;
+      } 
+
+      if (gamepad.axes[2] < -0.75) {
+        if (!this.snapTurning) {
+          doSnapTurn(context, 1);
+          this.snapTurning = true;
+        }
+        anySnapTurning = true;
+        break;
+      } 
+    }
+    if (!anySnapTurning) {
+      this.snapTurning = false;
+    }
+  }
+}


### PR DESCRIPTION
Adds snap turn support with a SnapTurn helper class, similar to Teleport.
Tested on the Oculus Quest. Will probably need amendments to support other controllers correctly.
Happy to change the design, for example to an ECSY component/system if you have suggestions.