### PR TITLE
Fix positional audio on xylophone

### DIFF
--- a/src/lib/PositionalAudioPolyphonic.js
+++ b/src/lib/PositionalAudioPolyphonic.js
@@ -8,7 +8,7 @@ export default class PositionalAudioPolyphonic extends THREE.Object3D {
 
     this.poolSize = poolSize || 5;
     for (var i = 0; i < this.poolSize; i++) {
-      this.children.push(new THREE.PositionalAudio(listener));
+      this.add(new THREE.PositionalAudio(listener));
     }
   }
 

--- a/src/stations/Xylophone.js
+++ b/src/stations/Xylophone.js
@@ -37,6 +37,7 @@ export function setup(ctx, hall) {
     note.userData.animation = 0;
     note.userData.resetY = note.position.y;
     note.userData.sound = new PositionalAudioPolyphonic(listener, 10);
+    note.add(note.userData.sound);
     audioLoader.load('assets/ogg/xylophone' + (i + 1) + '.ogg', buffer => {
       note.userData.sound.setBuffer(buffer);
     });


### PR DESCRIPTION
Fixes parenting on the xylophone's positional audio sources so that their positions are actually correct. There's still something off about the audio, and you can still cause the audio to distort on Quest, but this fixes the main offense.

Fixes #68